### PR TITLE
fix: change broken OSC URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-osc
 
-A no frills [Open Sound Control](http://opensoundcontrol.org/introduction-osc) client. Heavily inspired by [pyOSC](https://trac.v2.nl/wiki/pyOSC).
+A no frills [Open Sound Control](http://opensoundcontrol.org) client. Heavily inspired by [pyOSC](https://trac.v2.nl/wiki/pyOSC).
 
 Install using npm
 


### PR DESCRIPTION
looks like the page you've linked here doesn't exist anymore, and I can't seem to verify that it was renamed to something else. The root page does, however, seem to be a good intro.