### PR TITLE
tools: don't ignore scripts on publish

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
           npm ci
-          npm publish --ignore-scripts
+          npm publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Oops, the automation wasn't including scripts and broke CJS

Fixes: https://github.com/MylesBorins/node-osc/issues/54