### PR TITLE
tools: remove release script hack

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const version = "${{ github.ref }}".slice('refs/tags/'.length);
+            const version = "${{ github.ref }}";
             const { data: {name, body} } = await github.request(`GET /repos/${{ github.repository }}/release-notes`, {
               tag_name: version
             });


### PR DESCRIPTION
We no longer need to strip the ref from the tag