### PR TITLE
tools: simplify use of API for creating release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,11 +35,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const version = "${{ github.ref }}";
-            const { data: {name, body} } = await github.request(`POST /repos/${{ github.repository }}/releases/generate-notes`, {
-              tag_name: version
-            });
             await github.request(`POST /repos/${{ github.repository }}/releases`, {
               tag_name: version,
-              name,
-              body
+              generate_release_notes: true
             });


### PR DESCRIPTION
We no longer need two API calls. We can
alternatively pass a new boolean to the create
release API.