### PR TITLE
tools: update setup-node to use cache

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -32,10 +32,11 @@ jobs:
       with:
         ssh-key: ${{ secrets.DEPLOY_KEY }}
 
-    - name: Setup Node.js 14
-      uses: actions/setup-node@v1
+    - name: Setup Node.js
+      uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: '16'
+        cache: 'npm'
 
     - name: Install npm packages
       run: npm ci

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,9 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: '16'
+          cache: 'npm'
       - name: Publish
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,7 @@ jobs:
   run-tests:
     strategy:
       matrix:
-        node-version: [16.x, 14.x, 12.x]
+        node-version: ['16', '14', '12']
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
@@ -20,9 +20,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
 
     - name: Get npm cache directory
       if: matrix.os != 'windows-latest'


### PR DESCRIPTION
Currently we do not use a cache at all for dependencies, and while this repository does not have a lot this could still improve setup time