### PR TITLE
ci(release): remove "Checkout code" step from "create-github-release"

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,8 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
       - name: Create Release Notes
         uses: actions/github-script@v4.0.2
         with:


### PR DESCRIPTION
… job

In this step, it's unnecessary to check out the source since you aren't doing anything with it. At this point you only need github.ref