### PR TITLE
chore: drop support for Node.js 12 and 17

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,7 @@ jobs:
   run-tests:
     strategy:
       matrix:
-        node-version: ['17', '16', '14', '12']
+        node-version: ['18', '16', '14']
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "email": "myles.borins@gmail.com"
   },
   "engines": {
-    "node": "^12.22 || ^14.13 || >=16"
+    "node": "^14.13 || ^16.13 || >=18"
   },
   "license": "LGPL-2.1",
   "scripts": {


### PR DESCRIPTION
In preparation of Node.js 12 and 17 going EOL, and 18 being cut