### PR TITLE
chore: switch to node namespace for builtins

### DIFF
--- a/lib/Client.mjs
+++ b/lib/Client.mjs
@@ -1,4 +1,4 @@
-import { createSocket } from 'dgram';
+import { createSocket } from 'node:dgram';
 import oscMin from 'osc-min';
 import Message from './Message.mjs';
 

--- a/lib/Server.mjs
+++ b/lib/Server.mjs
@@ -1,5 +1,5 @@
-import { createSocket } from 'dgram';
-import { EventEmitter } from 'events';
+import { createSocket } from 'node:dgram';
+import { EventEmitter } from 'node:events';
 
 import decode from './internal/decode.mjs';
 


### PR DESCRIPTION
Now that we've dropped Node.js 12 we can start using "node:" syntax for builtins