### PR TITLE
chore: bump versions to accommodate node builtins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "tap": "^16.0.1"
       },
       "engines": {
-        "node": "^12.22 || ^14.13 || >=16"
+        "node": "^14.18 || ^16.13 || >=18"
       }
     },
     "node_modules/@babel/compat-data": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "email": "myles.borins@gmail.com"
   },
   "engines": {
-    "node": "^14.13 || ^16.13 || >=18"
+    "node": "^14.18 || ^16.13 || >=18"
   },
   "license": "LGPL-2.1",
   "scripts": {


### PR DESCRIPTION
Need to bump version of 14 to support `node:` in both ESM + CJS