### PR TITLE
message: add alias ability for type tags

### DIFF
--- a/lib/Message.mjs
+++ b/lib/Message.mjs
@@ -1,3 +1,10 @@
+const typeTags = {
+  s: 'string',
+  f: 'float',
+  i: 'integer',
+  b: 'blob'
+};
+
 class Argument {
   constructor(type, value) {
     this.type = type;
@@ -19,6 +26,7 @@ class Message {
       if (arg instanceof Array) {
         arg.forEach(a => this.append(a));
       } else if (arg.type) {
+        if (typeTags[arg.type]) arg.type = typeTags[arg.type];
         this.args.push(arg);
       } else {
         throw new Error(`don't know how to encode object ${arg}`);


### PR DESCRIPTION
Adds the ability to append a message using the short form of the type tag, matching how it will be encoded before going over the wire.

e.g.

```js
message.append({
  type: 'integer', 
  value: 123
});
```

Prior to this change the above would error.

As this functionality never worked before and wasn't expected I am treating this as a new feature rather than a bug fix.