### PR TITLE
Remove the get-port package and implement the functionality directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
       },
       "devDependencies": {
         "eslint": "^8.36.0",
-        "get-port": "^6.1.2",
         "rollup": "^4.9.5",
         "tap": "^18.4.2"
       },
@@ -2700,18 +2699,6 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-port": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
-      "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob": {
@@ -7603,12 +7590,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
-    },
-    "get-port": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
-      "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==",
       "dev": true
     },
     "glob": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "eslint": "^8.36.0",
-    "get-port": "^6.1.2",
     "rollup": "^4.9.5",
     "tap": "^18.4.2"
   }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -77,6 +77,7 @@ function walkTest(config) {
       },
       external: [
         'node:dgram',
+        'node:events',
         'node-osc',
         'osc-min',
         'tap',

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -77,7 +77,6 @@ function walkTest(config) {
       },
       external: [
         'node:dgram',
-        'get-port',
         'node-osc',
         'osc-min',
         'tap',

--- a/test/test-util.mjs
+++ b/test/test-util.mjs
@@ -1,0 +1,39 @@
+import { test } from 'tap';
+import { getPort } from './util.mjs';
+
+import { createSocket } from 'node:dgram';
+import { once } from 'node:events';
+
+test('getPort: valid range', async (t) => {
+  const port = await getPort(3000, 3500);
+  t.ok(port >= 3000 && port <= 3500, 'port should be in range');
+  const socket = createSocket('udp4');
+  socket.bind(port, (err) => {
+    t.error(err, 'port should be available');
+  });
+  await once(socket, 'listening');
+  socket.close();
+  await once(socket, 'close');
+  t.end();
+});
+
+test('getPort: invalid range', async (t) => {
+  t.rejects(() => getPort(3500, 3000), 'should throw an error for invalid range');
+  t.end();
+});
+
+test('getPort: timeout', async (t) => {
+  const sockets = [];
+  for (let i = 3001; i <= 3002; i++) {
+    const socket = createSocket('udp4');
+    socket.bind(i);
+    sockets.push(socket);
+  }  
+  await t.rejects(getPort(3001, 3002), {
+    message: 'No port available'
+  });
+  sockets.forEach((socket) => socket.close());
+  t.end();
+});
+
+

--- a/test/util.mjs
+++ b/test/util.mjs
@@ -1,8 +1,29 @@
-async function bootstrap(t) {
-  const {default: getPorts, portNumbers} = await import('get-port');
-  const port = await getPorts({
-    port: portNumbers(3000, 3500)
+import { createSocket } from 'node:dgram';
+
+// A custom getPort function that returns a promise that resolves with a random port within a range that is available
+function getPort(min = 3000, max = 3500) {
+  return new Promise((resolve) => {
+    // Create a socket
+    const socket = createSocket('udp4');
+    // Generate a random port within the range
+    const port = Math.floor(Math.random() * (max - min + 1)) + min;
+    // Try to bind the socket to the port
+    socket.bind(port, (err) => {
+      if (err) {
+        // If there is an error, try again with a different port
+        socket.close();
+        resolve(getPort(min, max));
+      } else {
+        // If successful, close the socket and resolve the promise with the port
+        socket.close();
+        resolve(port);
+      }
+    });
   });
+}
+
+async function bootstrap(t) {
+  const port = await getPort(3000, 3500);
   t.context = {
     port
   };

--- a/test/util.mjs
+++ b/test/util.mjs
@@ -2,11 +2,21 @@ import { createSocket } from 'node:dgram';
 
 // A custom getPort function that returns a promise that resolves with a random port within a range that is available
 function getPort(min = 3000, max = 3500) {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     // Create a socket
     const socket = createSocket('udp4');
     // Generate a random port within the range
     const port = Math.floor(Math.random() * (max - min + 1)) + min;
+    // Check if the port range is valid
+    if (min >= max) {
+      reject(new Error('Invalid port range'));
+      return;
+    }
+    // Set a timeout to reject the promise if no port is found
+    const timeout = setTimeout(() => {
+      socket.close();
+      reject(new Error('No port available'));
+    }, 3000);
     // Try to bind the socket to the port
     socket.bind(port, (err) => {
       if (err) {
@@ -14,7 +24,8 @@ function getPort(min = 3000, max = 3500) {
         socket.close();
         resolve(getPort(min, max));
       } else {
-        // If successful, close the socket and resolve the promise with the port
+        // If successful, clear the timeout, close the socket and resolve the promise with the port
+        clearTimeout(timeout);
         socket.close();
         resolve(port);
       }
@@ -30,5 +41,6 @@ async function bootstrap(t) {
 }
 
 export {
-  bootstrap
+  bootstrap,
+  getPort // Export the getPort function
 };


### PR DESCRIPTION
Remove the get-port package and implement the functionality directly

This PR was created with Copilot Workspace (v0.15). For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MylesBorins/node-osc?shareId=2b8ba5ec-96fc-421a-94fe-e7b9c5ecbc1d).