### PR TITLE
Remove osc-min dependency

### DIFF
--- a/lib/Client.mjs
+++ b/lib/Client.mjs
@@ -1,8 +1,28 @@
 import { createSocket } from 'node:dgram';
-import oscMin from 'osc-min';
 import Message from './Message.mjs';
 
-const { toBuffer } = oscMin;
+function toBuffer(message) {
+  const address = Buffer.from(message.address + '\0');
+  const args = message.args.map(arg => {
+    switch (typeof arg) {
+      case 'string':
+        return Buffer.from(arg + '\0');
+      case 'number':
+        const buf = Buffer.alloc(4);
+        if (Number.isInteger(arg)) {
+          buf.writeInt32BE(arg);
+        } else {
+          buf.writeFloatBE(arg);
+        }
+        return buf;
+      case 'boolean':
+        return Buffer.from(arg ? 'T' : 'F');
+      default:
+        throw new Error(`Unsupported argument type: ${typeof arg}`);
+    }
+  });
+  return Buffer.concat([address, ...args]);
+}
 
 class Client {
   constructor(host, port) {

--- a/lib/internal/decode.mjs
+++ b/lib/internal/decode.mjs
@@ -1,10 +1,99 @@
-import { fromBuffer } from 'osc-min';
+function fromBuffer(buffer) {
+  let offset = 0;
+
+  function readInt32() {
+    const value = buffer.readInt32BE(offset);
+    offset += 4;
+    return value;
+  }
+
+  function readFloat32() {
+    const value = buffer.readFloatBE(offset);
+    offset += 4;
+    return value;
+  }
+
+  function readString() {
+    const start = offset;
+    while (buffer[offset] !== 0) {
+      offset++;
+    }
+    const value = buffer.toString('ascii', start, offset);
+    offset += 4 - (offset % 4);
+    return value;
+  }
+
+  function readBlob() {
+    const size = readInt32();
+    const value = buffer.slice(offset, offset + size);
+    offset += size + (4 - (size % 4));
+    return value;
+  }
+
+  function readTimetag() {
+    const seconds = readInt32();
+    const fraction = readInt32();
+    return { seconds, fraction };
+  }
+
+  function readArguments(typeTag) {
+    const args = [];
+    for (let i = 0; i < typeTag.length; i++) {
+      switch (typeTag[i]) {
+        case 'i':
+          args.push(readInt32());
+          break;
+        case 'f':
+          args.push(readFloat32());
+          break;
+        case 's':
+          args.push(readString());
+          break;
+        case 'b':
+          args.push(readBlob());
+          break;
+        case 't':
+          args.push(readTimetag());
+          break;
+        default:
+          throw new Error(`Unsupported argument type: ${typeTag[i]}`);
+      }
+    }
+    return args;
+  }
+
+  function readMessage() {
+    const address = readString();
+    const typeTag = readString().slice(1);
+    const args = readArguments(typeTag);
+    return { oscType: 'message', address, args };
+  }
+
+  function readBundle() {
+    const timetag = readTimetag();
+    const elements = [];
+    while (offset < buffer.length) {
+      const size = readInt32();
+      const elementBuffer = buffer.slice(offset, offset + size);
+      offset += size;
+      elements.push(fromBuffer(elementBuffer));
+    }
+    return { oscType: 'bundle', timetag, elements };
+  }
+
+  if (buffer[0] === 35 && buffer[1] === 98 && buffer[2] === 117 && buffer[3] === 110 && buffer[4] === 100 && buffer[5] === 108 && buffer[6] === 101) {
+    offset += 8;
+    return readBundle();
+  } else {
+    return readMessage();
+  }
+}
 
 function sanitizeMessage(decoded) {
   const message = [];
   message.push(decoded.address);
   decoded.args.forEach(arg => {
-    message.push(arg.value);
+    message.push(arg);
   });
   return message;
 }

--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
     "type": "git",
     "url": "git+https://github.com/MylesBorins/node-osc.git"
   },
-  "dependencies": {
-    "osc-min": "^1.1.1"
-  },
   "devDependencies": {
     "@eslint/js": "^9.4.0",
     "eslint": "^9.4.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -34,7 +34,6 @@ function walkLib(config) {
       external: [
         'node:dgram',
         'node:events',
-        'osc-min',
         'jspack',
         '#decode'
       ]
@@ -59,7 +58,6 @@ function walkTest(config) {
         'node:dgram',
         'node:net',
         'node-osc',
-        'osc-min',
         'tap',
         '#decode'
       ]


### PR DESCRIPTION
Related to #115

Remove the `osc-min` dependency and implement `toBuffer` and `fromBuffer` functions directly.

* **package.json**
  - Remove the `osc-min` dependency.

* **lib/Client.mjs**
  - Implement the `toBuffer` function directly in this file.
  - Replace the import of `osc-min` with the new `toBuffer` function.

* **lib/internal/decode.mjs**
  - Implement the `fromBuffer` function directly in this file.
  - Replace the import of `osc-min` with the new `fromBuffer` function.

* **rollup.config.mjs**
  - Remove `osc-min` from the external dependencies.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MylesBorins/node-osc/issues/115?shareId=1fd63932-239e-4cc0-9bc2-d4b0485a07dd).