### PR TITLE
chore: drop support for node.js 18

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,7 @@ jobs:
   run-tests:
     strategy:
       matrix:
-        node-version: ['24', '22', '20', '18']
+        node-version: ['24', '22', '20']
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "email": "myles.borins@gmail.com"
   },
   "engines": {
-    "node": "^18.17.0 || ^20.5.0 || >=22.0.0"
+    "node": "^20.9.0 || ^22.11.0 || >=24.0.0"
   },
   "license": "LGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
This pull request updates the Node.js version compatibility across the project. The most important changes include removing support for Node.js 18 in testing workflows and updating the `engines` field in `package.json` to reflect higher minimum Node.js version requirements.

### Node.js version updates:

* [`.github/workflows/nodejs.yml`](diffhunk://#diff-e98936aa52a6dd7416e4296e9628456227d834f7245967383fd9ff80fd985dadL14-R14): Removed Node.js 18 from the matrix of versions used in the `run-tests` job. Testing now supports Node.js versions 20, 22, and 24.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R20): Updated the `engines` field to require Node.js versions `^20.9.0`, `^22.11.0`, or `>=24.0.0`, ensuring compatibility with newer versions.