### PR TITLE
README: Update Node versions + Bundle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install node-osc
 
 ## Written using ESM supports CJS
 
-Supports the latest versions of Node.js 12, 14, and 16 in both ESM + CJS
+Supports the latest versions of Node.js 20, 22, and 24 in both ESM + CJS
 
 ## Example
 
@@ -57,8 +57,6 @@ client.send(bundle));
 ```
 
 ### Listening for OSC bundles:
-
-**WARNING**: Bundle support is Experimental and subject to change at any point. 
 
 ```js
 import { Server } from 'node-osc';


### PR DESCRIPTION
#64 stabilised the bundle API and removed the experimental note in the README about sending bundles. This PR removes the same note about listening for bundles.

Various PRs have changed Node version support - this PR also updates the versions in the README to match those specified in `package.json`. There's an argument that this could just say LTS versions of Node, if that's the official support target? Or possibly "LTS node versions newer than version 20" or similar. 

I think both of these are worth doing to make it obvious that the library's up to date + stable. Love your work!

Let me know if you'd rather these were separate, or if I've misunderstood the bundle stability stuff!
