### PR TITLE
fix: ensure that node.js builtins are being imported

### DIFF
--- a/lib/internal/osc.mjs
+++ b/lib/internal/osc.mjs
@@ -3,6 +3,8 @@
 
 // Helper functions for OSC encoding/decoding
 
+import { Buffer } from 'node:buffer';
+
 function padString(str) {
   const nullTerminated = str + '\0';
   const padding = 4 - (nullTerminated.length % 4);

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -34,8 +34,10 @@ function walkLib(config) {
       external: [
         'node:dgram',
         'node:events',
+        'node:buffer',
         'jspack',
-        '#decode'
+        '#decode',
+        '#osc'
       ]
     });
   });
@@ -57,9 +59,11 @@ function walkTest(config) {
       external: [
         'node:dgram',
         'node:net',
+        'node:buffer',
         'node-osc',
         'tap',
-        '#decode'
+        '#decode',
+        '#osc'
       ]
     });
   });


### PR DESCRIPTION
This pull request updates module dependencies and imports to ensure proper usage of the Node.js `buffer` module and to improve build configuration for both library and test bundles.

**Dependency and Import Updates:**

* Added explicit import of `Buffer` from `node:buffer` in `lib/internal/osc.mjs` to ensure compatibility and clarity in buffer handling.

**Build Configuration Improvements:**

* Updated the `external` dependencies in the `rollup.config.mjs` for both library (`walkLib`) and test (`walkTest`) builds to include `node:buffer` and `#osc`, ensuring these modules are treated as external and not bundled. [[1]](diffhunk://#diff-47407fecafdf5f5cd55403c3de457833ddf9b6fab45253c04e1dc4c7cb4495b1R37-R40) [[2]](diffhunk://#diff-47407fecafdf5f5cd55403c3de457833ddf9b6fab45253c04e1dc4c7cb4495b1R62-R66)