### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/MylesBorins/node-osc/security/code-scanning/4](https://github.com/MylesBorins/node-osc/security/code-scanning/4)

In general, the fix is to explicitly define a `permissions:` block either at the workflow root (applies to all jobs) or within the specific job, granting only the minimum necessary scopes. For a simple CI workflow that just checks out code and runs tests, `contents: read` is typically sufficient, since no step needs to write to the repository or modify issues, PRs, or other resources.

The best fix here, without changing existing functionality, is to add a `permissions:` block at the top level of `.github/workflows/nodejs.yml`, alongside `name:` and `on:`, so it covers the `run-tests` job. Based on the shown steps, the workflow only needs to read repository contents, so we can safely set:

```yaml
permissions:
  contents: read
```

This leaves the rest of the workflow unchanged and constrains `GITHUB_TOKEN` to read-only repository contents, addressing the CodeQL warning and following least-privilege guidance. No additional methods, imports, or definitions are needed because this is purely a configuration change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
