### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow that is manually triggered
 
 name: Bump version
+permissions:
+  contents: read
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.


### PR DESCRIPTION
Potential fix for [https://github.com/MylesBorins/node-osc/security/code-scanning/2](https://github.com/MylesBorins/node-osc/security/code-scanning/2)

In general, to fix this type of problem, you explicitly declare a `permissions:` block at either the workflow root (applies to all jobs) or on individual jobs, restricting `GITHUB_TOKEN` to the minimal scopes needed. For a bump-version workflow that uses a deploy key for pushing, the job only needs read access to repository contents; write operations happen via SSH, not via `GITHUB_TOKEN`.

The single best fix here, without changing existing functionality, is to add a workflow-level `permissions` block just after the `name:` declaration. This will apply to the `bump-version` job and any future jobs in this workflow that don’t override permissions. Based on the current steps (checkout code, install dependencies, configure git, run `npm version`, and push using an SSH key), the minimal necessary permission is `contents: read`. The `actions/checkout` action needs repository contents read access; no other special scopes (issues, pull-requests, actions, etc.) are used. No additional imports or dependencies are needed; this is purely a YAML configuration change within `.github/workflows/bump-version.yml`.

Concretely:
- In `.github/workflows/bump-version.yml`, between line 3 (`name: Bump version`) and line 5 (the `# Controls when the action will run` comment), insert:

```yaml
permissions:
  contents: read
```

This constrains `GITHUB_TOKEN` to read-only on repository contents while leaving the rest of the job unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
