### PR TITLE
fix: publish correct esm and cjs type declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/
 dist/
 types/
 .tap/
+types-cjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,19 +43,31 @@ This document provides context and instructions for AI agents (GitHub Copilot, C
 The project uses **ESM as the source format** but provides **dual ESM/CommonJS support**:
 - Source files: `lib/**/*.mjs` (ESM)
 - Built CommonJS files: `dist/lib/**/*.js` (transpiled via Rollup)
-- Generated TypeScript definitions: `types/*.d.mts` (with `types/index.d.mts` as the package entry point)
+- Generated ESM TypeScript definitions: `types/*.d.mts` (with `types/index.d.mts` as the ESM type entry point)
+- Generated CommonJS TypeScript definitions: `dist/types/*.d.ts` (generated from the Rollup CommonJS output, with `dist/types/index.d.ts` as the CJS type entry point)
 
-**Important:** `types/index.d.mts` is the exported type entry point for both ESM and CommonJS consumers, and the supporting `.d.mts` files in `types/` are generated artifacts.
+**Important:**
+- `types/` contains generated declarations for the ESM source tree in `lib/`
+- `dist/types/` contains generated declarations for the CommonJS build in `dist/lib/`
+- Do not manually edit generated declaration files in either location
 
 ### Package Exports
 
 ```json
 {
+  "types": "./types/index.d.mts",
   "exports": {
-    "types": "./types/index.d.mts",
-    "require": "./dist/lib/index.js",
-    "import": "./lib/index.mjs",
-    "default": "./lib/index.mjs"
+    ".": {
+      "import": {
+        "types": "./types/index.d.mts",
+        "default": "./lib/index.mjs"
+      },
+      "require": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/lib/index.js"
+      },
+      "default": "./lib/index.mjs"
+    }
   }
 }
 ```
@@ -103,7 +115,8 @@ npm run clean
 
 1. **Clean**: Removes `dist/` and `types/` directories
 2. **Rollup**: Transpiles ESM to CommonJS in `dist/` directory
-3. **TypeScript**: Generates type definitions from JSDoc in `types/` directory
+3. **TypeScript (ESM declarations)**: Generates `.d.mts` type definitions from JSDoc in `types/` using the ESM source tree in `lib/`
+4. **TypeScript (CJS declarations)**: Generates `.d.ts` type definitions in `dist/types/` from the Rollup-generated CommonJS tree in `dist/lib/`
 
 The build is automatically run before publishing (`prepublishOnly` script).
 
@@ -146,9 +159,11 @@ async send(msg, ...args) { ... }
 ### Type System
 
 - TypeScript definitions are **generated** from JSDoc comments
-- Do not manually edit `types/*.d.mts` files
+- ESM declarations are generated from `lib/**/*.mjs` into `types/*.d.mts`
+- CJS declarations are generated from `dist/lib/**/*.js` into `dist/types/*.d.ts`
+- Do not manually edit generated declaration files in `types/` or `dist/types/`
 - Update JSDoc comments in source files instead
-- Run `npm run build:types` to regenerate types
+- Run `npm run build:types` to regenerate both ESM and CJS declarations
 
 ### Naming Conventions
 
@@ -176,8 +191,9 @@ When writing code that needs to work in both ESM and CJS:
 - `lib/osc.mjs` - Low-level encode/decode functions
 
 ### Build Artifacts
-- `dist/` - Transpiled CommonJS files (generated, do not edit)
-- `types/` - TypeScript type definitions (generated, do not edit)
+- `dist/lib/` - Transpiled CommonJS runtime files (generated, do not edit)
+- `dist/types/` - CommonJS TypeScript declarations generated from `dist/lib/` (generated, do not edit)
+- `types/` - ESM TypeScript declarations generated from `lib/` (generated, do not edit)
 
 ### Tests
 - `test/test-*.mjs` - Test files using tap framework
@@ -196,7 +212,8 @@ When writing code that needs to work in both ESM and CJS:
 - `package.json` - Package configuration, scripts, exports
 - `eslint.config.mjs` - ESLint configuration
 - `rollup.config.mjs` - Rollup build configuration (ESM to CJS)
-- `tsconfig.json` - TypeScript compiler options for type generation
+- `tsconfig.json` - TypeScript compiler options for ESM type generation from `lib/`
+- `tsconfig.cjs.json` - TypeScript compiler options for CJS type generation from `dist/lib/`
 - `jsdoc.json` - JSDoc configuration for documentation generation
 - `scripts/generate-docs.mjs` - Regenerates API documentation and handles API doc anchor/link formatting logic
 
@@ -283,7 +300,7 @@ const decoded = decode(buffer);
 ### Module Resolution
 
 - **Dual package hazard**: The package exports both ESM and CJS - don't mix them
-- **Type imports**: TypeScript consumers get types automatically from `types/index.d.mts`
+- **Type imports**: ESM consumers resolve types from `types/index.d.mts`; CJS consumers resolve types from `dist/types/index.d.ts`
 - **Internal imports**: Use `#decode` subpath for internal modules
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ Supports Node.js 20, 22, and 24+ in both ESM and CJS environments.
 
 TypeScript type definitions are included! No need to install `@types/node-osc`.
 
-The types are automatically generated from JSDoc comments during the build process and included with the package. A single `.d.mts` type definition format is provided that works for both ESM and CommonJS consumers.
+The types are automatically generated from JSDoc comments during the build process and included with the package:
+- ESM consumers resolve declarations from `types/*.d.mts`
+- CommonJS consumers resolve declarations from `dist/types/*.d.ts`
+
+This package publishes separate generated declaration outputs for the ESM source tree and the CommonJS build so TypeScript can resolve the correct types for each entry point.
 
 **Note:** If you previously installed `@types/node-osc`, you should uninstall it to avoid conflicts:
 ```bash

--- a/package.json
+++ b/package.json
@@ -2,11 +2,19 @@
   "name": "node-osc",
   "description": "pyOSC inspired library for sending and receiving OSC messages",
   "version": "11.4.0",
+  "types": "./types/index.d.mts",
   "exports": {
-    "types": "./types/index.d.mts",
-    "require": "./dist/lib/index.js",
-    "import": "./lib/index.mjs",
-    "default": "./lib/index.mjs"
+    ".": {
+      "import": {
+        "types": "./types/index.d.mts",
+        "default": "./lib/index.mjs"
+      },
+      "require": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/lib/index.js"
+      },
+      "default": "./lib/index.mjs"
+    }
   },
   "imports": {
     "#decode": {
@@ -25,7 +33,7 @@
   "scripts": {
     "clean": "rm -rf dist/ types/",
     "build": "npm run clean && rollup --config rollup.config.mjs && npm run build:types",
-    "build:types": "tsc",
+    "build:types": "tsc && tsc -p tsconfig.cjs.json",
     "docs": "node scripts/generate-docs.mjs",
     "prepublishOnly": "npm run build",
     "lint": "eslint \"lib/**/*.mjs\" \"test/test-*.mjs\" \"examples/*.js\" \"examples/*.mjs\" \"scripts/*.mjs\" rollup.config.mjs",
@@ -46,6 +54,17 @@
     "type": "git",
     "url": "git+https://github.com/MylesBorins/node-osc.git"
   },
+  "files": [
+    "lib/",
+    "dist/lib/",
+    "dist/types/",
+    "types/",
+    "docs/",
+    "examples/",
+    "README.md",
+    "LICENSE",
+    "SECURITY.md"
+  ],
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "eslint": "^10.0.3",

--- a/test/fixtures/types/test-cjs-types.ts
+++ b/test/fixtures/types/test-cjs-types.ts
@@ -1,6 +1,6 @@
 // Test CJS-style TypeScript imports
 import type { Client, Server, Message, Bundle } from 'node-osc';
-const osc = require('node-osc');
+const osc: typeof import('node-osc') = require('node-osc');
 
 // Create server first (typical usage pattern)
 const server: Server = new osc.Server(3333, '0.0.0.0');
@@ -18,3 +18,6 @@ const bundle: Bundle = new osc.Bundle(['/one', 1]);
 // Test encode/decode with consistent type annotations
 const encoded: Buffer = osc.encode(message);
 const decoded: Object = osc.decode(encoded);
+void client;
+void bundle;
+void decoded;

--- a/test/fixtures/types/test-esm-types.mts
+++ b/test/fixtures/types/test-esm-types.mts
@@ -1,6 +1,6 @@
 // Test ESM TypeScript imports with Top-Level Await
 import { once } from 'node:events';
-import { Client, Server, Message, Bundle, encode, decode } from 'node-osc';
+import { Message, Bundle, Server, Client, encode, decode } from 'node-osc';
 
 // Create server first (typical usage pattern)
 const server: Server = new Server(3333, '0.0.0.0');
@@ -34,3 +34,4 @@ bundle.append(['/three', 3]);
 // Test encode/decode with consistent type annotations
 const encoded: Buffer = encode(message);
 const decoded: Object = decode(encoded);
+void decoded;

--- a/test/fixtures/types/tsconfig-cjs.test.json
+++ b/test/fixtures/types/tsconfig-cjs.test.json
@@ -2,14 +2,10 @@
   "compilerOptions": {
     "noEmit": true,
     "skipLibCheck": true,
-    "module": "preserve",
-    "esModuleInterop": true,
+    "module": "Node16",
     "target": "ES2022",
-    "moduleResolution": "bundler",
-    "types": ["node"],
-    "paths": {
-      "node-osc": ["../../../types/index.d.mts"]
-    }
+    "moduleResolution": "Node16",
+    "types": ["node"]
   },
   "include": [
     "test-cjs-types.ts"

--- a/test/fixtures/types/tsconfig-esm.test.json
+++ b/test/fixtures/types/tsconfig-esm.test.json
@@ -2,17 +2,13 @@
   "compilerOptions": {
     "noEmit": true,
     "skipLibCheck": true,
-    "esModuleInterop": true,
-    "module": "ES2022",
+    "module": "NodeNext",
     "target": "ES2022",
-    "moduleResolution": "bundler",
+    "moduleResolution": "NodeNext",
     "types": ["node"],
-    "rootDir": ".",
-    "paths": {
-      "node-osc": ["../../../types/index.d.mts"]
-    }
+    "rootDir": "."
   },
   "include": [
-    "test-esm-types.ts"
+    "test-esm-types.mts"
   ]
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true,
+    "outDir": "./dist/types",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "resolveJsonModule": true,
+    "rootDir": "./dist/lib"
+  },
+  "include": [
+    "dist/lib/**/*.js"
+  ],
+  "exclude": [
+    "node_modules",
+    "test"
+  ]
+}


### PR DESCRIPTION
## Summary

fixes: https://github.com/MylesBorins/node-osc/issues/220

This fixes the package’s published type layout for dual ESM/CommonJS consumers.

Previously, the package only published a single ESM-flavored declaration entry, which could lead to incorrect or incomplete type resolution for CommonJS consumers and was flagged by external tooling.

## What changed

- Generate **ESM declarations** from `lib/` into `types/`
- Generate **CommonJS declarations** from the Rollup CJS build in `dist/lib/` into `dist/types/`
- Update `package.json` conditional exports so:
  - `import` resolves to `types/index.d.mts`
  - `require` resolves to `dist/types/index.d.ts`
- Update type fixtures/tests to validate both ESM and CJS consumers
- Document the type generation and publish layout in `README.md` and `AGENTS.md`
- Add a `files` whitelist so npm only publishes the runtime, declarations, docs, and examples

## Why

This package ships separate ESM and CommonJS runtime entry points, so the published type metadata should match that layout as well. Generating CJS declarations from the Rollup-produced CJS tree keeps the declaration output aligned with the actual CommonJS runtime shape while avoiding hand-maintained type wrappers.

## Validation

- `npm test`
- `npm pack --dry-run`
- Installed the packed tarball into a fresh consumer project and verified:
  - ESM runtime import works
  - CJS runtime require works
  - ESM TypeScript resolution works
  - CJS TypeScript resolution works

## Notes

This keeps JSDoc in the ESM source as the single source of truth. The CJS declarations are generated from the built CommonJS output rather than maintained separately by hand.
