### PR TITLE
feat: add support for the "null" argument type

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -278,6 +278,7 @@ Automatically detects the type based on the JavaScript type:
 - Strings are encoded as OSC strings
 - Booleans are encoded as OSC booleans
 - Buffers are encoded as OSC blobs
+- Null values are encoded as OSC nils
 - Arrays are recursively appended
 - Objects with a 'type' property are used as-is
 
@@ -301,6 +302,7 @@ msg.append(42);           // Integer
 msg.append(3.14);         // Float
 msg.append('hello');      // String
 msg.append(true);         // Boolean
+msg.append(null);         // Nil
 ```
 
 ```javascript

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -221,6 +221,7 @@ OSC supports several data types. node-osc automatically detects types for common
 | Float number | `float` | Decimal numbers (e.g., 3.14, -0.5) |
 | String | `string` | Text values (e.g., "hello") |
 | Boolean | `boolean` | true or false |
+| Null | `nil` | null |
 | Buffer | `blob` | Binary data |
 | MIDI object/Buffer | `midi` | MIDI messages (4 bytes: port, status, data1, data2) |
 
@@ -248,6 +249,7 @@ msg.append({ type: 'float', value: 42 });
 msg.append({ type: 'f', value: 42 });  // 'f' = float
 msg.append({ type: 'i', value: 3.14 }); // 'i' = integer (truncates)
 msg.append({ type: 's', value: 'text' }); // 's' = string
+msg.append({ type: 'n', value: null }); // 'n' = null
 msg.append({ type: 'b', value: Buffer.from('data') }); // 'b' = blob
 msg.append({ type: 'm', value: { port: 0, status: 144, data1: 60, data2: 127 } }); // 'm' = MIDI
 ```
@@ -257,6 +259,7 @@ msg.append({ type: 'm', value: { port: 0, status: 144, data1: 60, data2: 127 } }
 - `'i'` or `'integer'` - 32-bit integer
 - `'f'` or `'float'` - 32-bit float
 - `'s'` or `'string'` - OSC string
+- `'n'` or `'null'` - Null
 - `'b'` or `'blob'` - Binary blob
 - `'m'` or `'midi'` - MIDI message (4 bytes)
 - `'boolean'` - Boolean value (true/false)

--- a/lib/Message.mjs
+++ b/lib/Message.mjs
@@ -4,7 +4,7 @@ const typeTags = {
   i: 'integer',
   b: 'blob',
   m: 'midi',
-  n: 'null'
+  N: 'null'
 };
 
 /**

--- a/lib/Message.mjs
+++ b/lib/Message.mjs
@@ -3,7 +3,8 @@ const typeTags = {
   f: 'float',
   i: 'integer',
   b: 'blob',
-  m: 'midi'
+  m: 'midi',
+  n: 'null'
 };
 
 /**
@@ -109,7 +110,9 @@ class Message {
     let argOut;
     switch (typeof arg) {
     case 'object':
-      if (Buffer.isBuffer(arg)) {
+      if (arg === null) {
+        argOut = new Argument('null', arg);
+      } else if (Buffer.isBuffer(arg)) {
         this.args.push(arg);
       } else if (arg instanceof Array) {
         arg.forEach(a => this.append(a));

--- a/lib/osc.mjs
+++ b/lib/osc.mjs
@@ -108,7 +108,7 @@ function readTimeTag(buffer, offset) {
   }
   const seconds = buffer.readUInt32BE(offset);
   const fraction = buffer.readUInt32BE(offset + 4);
-  
+
   let value;
   if (seconds === 0 && fraction === 1) {
     // Immediate execution
@@ -119,14 +119,14 @@ function readTimeTag(buffer, offset) {
     const fractionalSeconds = fraction / 0x100000000;
     value = unixSeconds + fractionalSeconds;
   }
-  
+
   return { value, offset: offset + 8 };
 }
 
 function writeMidi(value) {
   // MIDI message is 4 bytes: port id, status byte, data1, data2
   const buffer = Buffer.alloc(4);
-  
+
   if (Buffer.isBuffer(value)) {
     if (value.length !== 4) {
       throw new Error('MIDI message must be exactly 4 bytes');
@@ -141,7 +141,7 @@ function writeMidi(value) {
   } else {
     throw new Error('MIDI value must be a 4-byte Buffer or object with port, status, data1, data2 properties');
   }
-  
+
   return buffer;
 }
 
@@ -149,7 +149,7 @@ function readMidi(buffer, offset) {
   if (offset + 4 > buffer.length) {
     throw new Error('Not enough bytes for MIDI message');
   }
-  
+
   const value = buffer.subarray(offset, offset + 4);
   return { value, offset: offset + 4 };
 }
@@ -183,11 +183,14 @@ function encodeArgument(arg) {
       case 'm':
       case 'midi':
         return { tag: 'm', data: writeMidi(arg.value) };
+      case 'N':
+      case 'null':
+        return { tag: 'N', data: Buffer.alloc(0) };
       default:
         throw new Error(`Unknown argument type: ${arg.type}`);
     }
   }
-  
+
   // Infer type from JavaScript type
   switch (typeof arg) {
     case 'number':
@@ -233,29 +236,29 @@ function decodeArgument(tag, buffer, offset) {
 
 /**
  * Encode an OSC message or bundle to a Buffer.
- * 
+ *
  * This low-level function converts OSC messages and bundles into binary format
  * for transmission or storage. Useful for sending OSC over custom transports
  * (WebSocket, TCP, HTTP), storing to files, or implementing custom OSC routers.
- * 
+ *
  * @param {Object} message - OSC message or bundle object with oscType property
  * @returns {Buffer} The encoded OSC data ready for transmission
- * 
+ *
  * @example
  * // Encode a message
  * import { Message, encode } from 'node-osc';
- * 
+ *
  * const message = new Message('/oscillator/frequency', 440);
  * const buffer = encode(message);
  * console.log('Encoded bytes:', buffer.length);
- * 
+ *
  * @example
  * // Encode a bundle
  * import { Bundle, encode } from 'node-osc';
- * 
+ *
  * const bundle = new Bundle(['/one', 1], ['/two', 2]);
  * const buffer = encode(bundle);
- * 
+ *
  * @example
  * // Send over WebSocket
  * const buffer = encode(message);
@@ -274,16 +277,16 @@ function encodeMessageToBuffer(message) {
   // Address pattern (padded string)
   // Type tag string (padded string starting with ,)
   // Arguments (encoded according to type tags)
-  
+
   const address = padString(message.address);
   const addressBuffer = Buffer.from(address);
-  
+
   const encodedArgs = message.args.map(encodeArgument);
   const typeTags = ',' + encodedArgs.map(arg => arg.tag).join('');
   const typeTagsBuffer = Buffer.from(padString(typeTags));
-  
+
   const argumentBuffers = encodedArgs.map(arg => arg.data);
-  
+
   return Buffer.concat([addressBuffer, typeTagsBuffer, ...argumentBuffers]);
 }
 
@@ -292,12 +295,12 @@ function encodeBundleToBuffer(bundle) {
   // "#bundle" (padded string)
   // Timetag (8 bytes)
   // Elements (each prefixed with size)
-  
+
   const bundleString = padString('#bundle');
   const bundleStringBuffer = Buffer.from(bundleString);
-  
+
   const timetagBuffer = writeTimeTag(bundle.timetag);
-  
+
   const elementBuffers = bundle.elements.map(element => {
     let elementBuffer;
     if (element.oscType === 'bundle') {
@@ -308,37 +311,37 @@ function encodeBundleToBuffer(bundle) {
     const sizeBuffer = writeInt32(elementBuffer.length);
     return Buffer.concat([sizeBuffer, elementBuffer]);
   });
-  
+
   return Buffer.concat([bundleStringBuffer, timetagBuffer, ...elementBuffers]);
 }
 
 /**
  * Decode a Buffer containing OSC data into a message or bundle object.
- * 
+ *
  * This low-level function parses binary OSC data back into JavaScript objects.
  * Useful for receiving OSC over custom transports, reading from files,
  * or implementing custom OSC routers.
- * 
+ *
  * @param {Buffer} buffer - The Buffer containing OSC data
  * @returns {Object} The decoded OSC message or bundle. Messages have
  *   {oscType: 'message', address: string, args: Array}, bundles have
  *   {oscType: 'bundle', timetag: number, elements: Array}
  * @throws {Error} If the buffer contains malformed OSC data
- * 
+ *
  * @example
  * // Decode received data
  * import { decode } from 'node-osc';
- * 
+ *
  * const decoded = decode(buffer);
  * if (decoded.oscType === 'message') {
  *   console.log('Address:', decoded.address);
  *   console.log('Arguments:', decoded.args);
  * }
- * 
+ *
  * @example
  * // Round-trip encode/decode
  * import { Message, encode, decode } from 'node-osc';
- * 
+ *
  * const original = new Message('/test', 42, 'hello');
  * const buffer = encode(original);
  * const decoded = decode(buffer);
@@ -355,30 +358,30 @@ function decode(buffer) {
 
 function decodeMessageFromBuffer(buffer) {
   let offset = 0;
-  
+
   // Read address pattern
   const addressResult = readString(buffer, offset);
   const address = addressResult.value;
   offset = addressResult.offset;
-  
+
   // Read type tag string
   const typeTagsResult = readString(buffer, offset);
   const typeTags = typeTagsResult.value;
   offset = typeTagsResult.offset;
-  
+
   if (!typeTags.startsWith(',')) {
     throw new Error('Malformed Packet');
   }
-  
+
   const tags = typeTags.slice(1); // Remove leading comma
   const args = [];
-  
+
   for (const tag of tags) {
     const argResult = decodeArgument(tag, buffer, offset);
     args.push({ value: argResult.value });
     offset = argResult.offset;
   }
-  
+
   return {
     oscType: 'message',
     address,
@@ -388,14 +391,14 @@ function decodeMessageFromBuffer(buffer) {
 
 function decodeBundleFromBuffer(buffer) {
   let offset = 8; // Skip "#bundle\0"
-  
+
   // Read timetag
   const timetagResult = readTimeTag(buffer, offset);
   const timetag = timetagResult.value;
   offset = timetagResult.offset;
-  
+
   const elements = [];
-  
+
   while (offset < buffer.length) {
     // Read element size
     const sizeResult = readInt32(buffer, offset);
@@ -404,14 +407,14 @@ function decodeBundleFromBuffer(buffer) {
     if (size <= 0 || offset + size > buffer.length) {
       throw new Error('Malformed Packet');
     }
-    
+
     // Read element data
     const elementBuffer = buffer.subarray(offset, offset + size);
     const element = decode(elementBuffer);
     elements.push(element);
     offset += size;
   }
-  
+
   return {
     oscType: 'bundle',
     timetag,

--- a/lib/osc.mjs
+++ b/lib/osc.mjs
@@ -108,7 +108,7 @@ function readTimeTag(buffer, offset) {
   }
   const seconds = buffer.readUInt32BE(offset);
   const fraction = buffer.readUInt32BE(offset + 4);
-
+  
   let value;
   if (seconds === 0 && fraction === 1) {
     // Immediate execution
@@ -119,14 +119,14 @@ function readTimeTag(buffer, offset) {
     const fractionalSeconds = fraction / 0x100000000;
     value = unixSeconds + fractionalSeconds;
   }
-
+  
   return { value, offset: offset + 8 };
 }
 
 function writeMidi(value) {
   // MIDI message is 4 bytes: port id, status byte, data1, data2
   const buffer = Buffer.alloc(4);
-
+  
   if (Buffer.isBuffer(value)) {
     if (value.length !== 4) {
       throw new Error('MIDI message must be exactly 4 bytes');
@@ -141,7 +141,7 @@ function writeMidi(value) {
   } else {
     throw new Error('MIDI value must be a 4-byte Buffer or object with port, status, data1, data2 properties');
   }
-
+  
   return buffer;
 }
 
@@ -149,7 +149,7 @@ function readMidi(buffer, offset) {
   if (offset + 4 > buffer.length) {
     throw new Error('Not enough bytes for MIDI message');
   }
-
+  
   const value = buffer.subarray(offset, offset + 4);
   return { value, offset: offset + 4 };
 }
@@ -190,7 +190,7 @@ function encodeArgument(arg) {
         throw new Error(`Unknown argument type: ${arg.type}`);
     }
   }
-
+  
   // Infer type from JavaScript type
   switch (typeof arg) {
     case 'number':
@@ -236,29 +236,29 @@ function decodeArgument(tag, buffer, offset) {
 
 /**
  * Encode an OSC message or bundle to a Buffer.
- *
+ * 
  * This low-level function converts OSC messages and bundles into binary format
  * for transmission or storage. Useful for sending OSC over custom transports
  * (WebSocket, TCP, HTTP), storing to files, or implementing custom OSC routers.
- *
+ * 
  * @param {Object} message - OSC message or bundle object with oscType property
  * @returns {Buffer} The encoded OSC data ready for transmission
- *
+ * 
  * @example
  * // Encode a message
  * import { Message, encode } from 'node-osc';
- *
+ * 
  * const message = new Message('/oscillator/frequency', 440);
  * const buffer = encode(message);
  * console.log('Encoded bytes:', buffer.length);
- *
+ * 
  * @example
  * // Encode a bundle
  * import { Bundle, encode } from 'node-osc';
- *
+ * 
  * const bundle = new Bundle(['/one', 1], ['/two', 2]);
  * const buffer = encode(bundle);
- *
+ * 
  * @example
  * // Send over WebSocket
  * const buffer = encode(message);
@@ -277,16 +277,16 @@ function encodeMessageToBuffer(message) {
   // Address pattern (padded string)
   // Type tag string (padded string starting with ,)
   // Arguments (encoded according to type tags)
-
+  
   const address = padString(message.address);
   const addressBuffer = Buffer.from(address);
-
+  
   const encodedArgs = message.args.map(encodeArgument);
   const typeTags = ',' + encodedArgs.map(arg => arg.tag).join('');
   const typeTagsBuffer = Buffer.from(padString(typeTags));
-
+  
   const argumentBuffers = encodedArgs.map(arg => arg.data);
-
+  
   return Buffer.concat([addressBuffer, typeTagsBuffer, ...argumentBuffers]);
 }
 
@@ -295,12 +295,12 @@ function encodeBundleToBuffer(bundle) {
   // "#bundle" (padded string)
   // Timetag (8 bytes)
   // Elements (each prefixed with size)
-
+  
   const bundleString = padString('#bundle');
   const bundleStringBuffer = Buffer.from(bundleString);
-
+  
   const timetagBuffer = writeTimeTag(bundle.timetag);
-
+  
   const elementBuffers = bundle.elements.map(element => {
     let elementBuffer;
     if (element.oscType === 'bundle') {
@@ -311,37 +311,37 @@ function encodeBundleToBuffer(bundle) {
     const sizeBuffer = writeInt32(elementBuffer.length);
     return Buffer.concat([sizeBuffer, elementBuffer]);
   });
-
+  
   return Buffer.concat([bundleStringBuffer, timetagBuffer, ...elementBuffers]);
 }
 
 /**
  * Decode a Buffer containing OSC data into a message or bundle object.
- *
+ * 
  * This low-level function parses binary OSC data back into JavaScript objects.
  * Useful for receiving OSC over custom transports, reading from files,
  * or implementing custom OSC routers.
- *
+ * 
  * @param {Buffer} buffer - The Buffer containing OSC data
  * @returns {Object} The decoded OSC message or bundle. Messages have
  *   {oscType: 'message', address: string, args: Array}, bundles have
  *   {oscType: 'bundle', timetag: number, elements: Array}
  * @throws {Error} If the buffer contains malformed OSC data
- *
+ * 
  * @example
  * // Decode received data
  * import { decode } from 'node-osc';
- *
+ * 
  * const decoded = decode(buffer);
  * if (decoded.oscType === 'message') {
  *   console.log('Address:', decoded.address);
  *   console.log('Arguments:', decoded.args);
  * }
- *
+ * 
  * @example
  * // Round-trip encode/decode
  * import { Message, encode, decode } from 'node-osc';
- *
+ * 
  * const original = new Message('/test', 42, 'hello');
  * const buffer = encode(original);
  * const decoded = decode(buffer);
@@ -358,30 +358,30 @@ function decode(buffer) {
 
 function decodeMessageFromBuffer(buffer) {
   let offset = 0;
-
+  
   // Read address pattern
   const addressResult = readString(buffer, offset);
   const address = addressResult.value;
   offset = addressResult.offset;
-
+  
   // Read type tag string
   const typeTagsResult = readString(buffer, offset);
   const typeTags = typeTagsResult.value;
   offset = typeTagsResult.offset;
-
+  
   if (!typeTags.startsWith(',')) {
     throw new Error('Malformed Packet');
   }
-
+  
   const tags = typeTags.slice(1); // Remove leading comma
   const args = [];
-
+  
   for (const tag of tags) {
     const argResult = decodeArgument(tag, buffer, offset);
     args.push({ value: argResult.value });
     offset = argResult.offset;
   }
-
+  
   return {
     oscType: 'message',
     address,
@@ -391,14 +391,14 @@ function decodeMessageFromBuffer(buffer) {
 
 function decodeBundleFromBuffer(buffer) {
   let offset = 8; // Skip "#bundle\0"
-
+  
   // Read timetag
   const timetagResult = readTimeTag(buffer, offset);
   const timetag = timetagResult.value;
   offset = timetagResult.offset;
-
+  
   const elements = [];
-
+  
   while (offset < buffer.length) {
     // Read element size
     const sizeResult = readInt32(buffer, offset);
@@ -407,14 +407,14 @@ function decodeBundleFromBuffer(buffer) {
     if (size <= 0 || offset + size > buffer.length) {
       throw new Error('Malformed Packet');
     }
-
+    
     // Read element data
     const elementBuffer = buffer.subarray(offset, offset + size);
     const element = decode(elementBuffer);
     elements.push(element);
     offset += size;
   }
-
+  
   return {
     oscType: 'bundle',
     timetag,

--- a/test/test-encode-decode.mjs
+++ b/test/test-encode-decode.mjs
@@ -171,18 +171,11 @@ test('encode and decode: MIDI messages with object', (t) => {
 });
 
 test('encode and decode: null type tag', (t) => {
-  // Create a message with null value by manually constructing the buffer
-  // OSC format: address + type tags + no data for 'N' type
-  const addressBuf = Buffer.from('/test\0\0\0', 'utf8');
-  const typeTagsBuf = Buffer.from(',N\0\0', 'utf8');
-  const buffer = Buffer.concat([addressBuf, typeTagsBuf]);
-  
+  const message = new Message('/midi', { type: 'N', value: null });
+  const buffer = encode(message);
   const decoded = decode(buffer);
   
-  t.equal(decoded.oscType, 'message', 'should decode as message');
-  t.equal(decoded.address, '/test', 'should have correct address');
-  t.equal(decoded.args[0].value, null, 'should decode null value');
-  
+  t.equal(decoded.args[0].value, null, 'should handle N type');
   t.end();
 });
 

--- a/test/test-message.mjs
+++ b/test/test-message.mjs
@@ -224,6 +224,33 @@ test('message: Buffer as blob', async (t) => {
   client.send(m);
 });
 
+test('message: null', async (t) => {
+  const server = new Server(0, '127.0.0.1');
+  await once(server, 'listening');
+  const client = new Client('127.0.0.1', server.port);
+
+  t.plan(1);
+  t.teardown(async () => {
+    await server.close();
+    await client.close();
+  });
+
+  const m = new Message('/address');
+  m.append(null);
+  m.append({type: "null", value: null});
+
+  server.on('message', (msg) => {
+    const expected = [
+      '/address',
+      null,
+      null
+    ];
+    t.same(msg, expected, `We reveived the payload: ${msg}`);
+  });
+
+  client.send(m);
+});
+
 // test('message: timetag', (t) => {
 //   const oscServer = new osc.Server(3333, '127.0.0.1');
 //   const client = new osc.Client('127.0.0.1', 3333);

--- a/test/test-osc-internal.mjs
+++ b/test/test-osc-internal.mjs
@@ -1003,3 +1003,31 @@ test('osc: explicit F type', (t) => {
   t.equal(decoded.args[0].value, false);
   t.end();
 });
+
+test('osc: null type', (t) => {
+  const message = {
+    oscType: 'message',
+    address: '/test',
+    args: [{type: 'null', value: null}]
+  };
+  
+  const buffer = encode(message);
+  const decoded = decode(buffer);
+  
+  t.equal(decoded.args[0].value, null);
+  t.end();
+});
+
+test('osc: N type', (t) => {
+  const message = {
+    oscType: 'message',
+    address: '/test',
+    args: [{ type: 'N', value: null }]
+  };
+  
+  const buffer = encode(message);
+  const decoded = decode(buffer);
+  
+  t.equal(decoded.args[0].value, null);
+  t.end();
+});


### PR DESCRIPTION
node-osc < 10 used to support sending `null` values, which are supported by the OSC spec (Nil, `N`) as well. Receiving `null` is still supported by node-osc >= 10, but sending leads to an error. 

This PR adds support for this type here and a test case to make sure everything is sent as expected.

Let me know if anything's missing. I'm looking forward to your reply!

