### PR TITLE
fix(docs): simplify JSDoc type reference in Server.send and regenerate API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ node_modules
 .nyc_output/
 coverage/
 dist/
-types/
+/types/
 .tap/
 types-cjs

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,6 +13,7 @@ For usage guides, best practices, and troubleshooting, see the **[Guide](./GUIDE
 
 - [Server](#server)
   - [Constructor](#server-constructor)
+  - [send()](#serversend)
   - [close()](#serverclose)
 - [Client](#client)
   - [Constructor](#client-constructor)
@@ -84,6 +85,42 @@ server.on('message', (msg) => {
 server.on('/note', (msg) => {
   const [address, pitch, velocity] = msg;
   console.log(`Note: ${pitch}, Velocity: ${velocity}`);
+});
+```
+
+
+### Server.send()
+
+Send an OSC message or bundle from the server's bound socket.
+
+This method can be used with either a callback or as a Promise.
+
+**Parameters:**
+
+- `message` *{Message | Bundle | Array | string}* - The message, bundle, address, or array to send.
+- `port` *{number}* - The remote port to send to.
+- `host` *{string}* - The remote host to send to.
+- `cb` *{function}* (optional) - Optional callback function called when send completes.
+
+**Returns:** *{Promise.<void> | undefined}* - Returns a Promise if no callback is provided.
+
+**Throws:**
+
+- *{Error}* - If the server socket is not yet listening.
+- *{TypeError}* - If the message format is invalid.
+- *{ReferenceError}* - If attempting to send on a closed socket.
+
+**Examples:**
+
+```javascript
+// Send an address-only message
+await server.send('/ping', 9000, '127.0.0.1');
+```
+
+```javascript
+// Send an array message
+server.send(['/ack', 1], 9000, '192.168.1.42', (err) => {
+  if (err) console.error(err);
 });
 ```
 

--- a/lib/Server.mjs
+++ b/lib/Server.mjs
@@ -4,6 +4,9 @@ import performSend from './internal/send.mjs';
 
 import decode from '#decode';
 
+/** @typedef {import('./Message.mjs').default} Message */
+/** @typedef {import('./Bundle.mjs').default} Bundle */
+
 function createSocketNotReadyError() {
   return new Error('Cannot send message before server is listening. Wait for the "listening" event.');
 }

--- a/lib/Server.mjs
+++ b/lib/Server.mjs
@@ -139,7 +139,7 @@ class Server extends EventEmitter {
    * 
    * This method can be used with either a callback or as a Promise.
    * 
-   * @param {import('./Message.mjs').default|import('./Bundle.mjs').default|Array|string} message - The message, bundle, address, or array to send.
+   * @param {Message|Bundle|Array|string} message - The message, bundle, address, or array to send.
    * @param {number} port - The remote port to send to.
    * @param {string} host - The remote host to send to.
    * @param {Function} [cb] - Optional callback function called when send completes.

--- a/test/fixtures/types/tsconfig-esm.test.json
+++ b/test/fixtures/types/tsconfig-esm.test.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "noEmit": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "module": "NodeNext",
     "target": "ES2022",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
Replaced verbose import-qualified type with plain Message|Bundle in the Server.send() JSDoc, and regenerated docs/API.md to include the missing Server.send() section.