### PR TITLE
ci: add docs freshness check

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,3 +33,21 @@ jobs:
 
     - name: Test
       run: npm run test
+
+  check-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Use Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        cache: npm
+
+    - name: Install Dependencies
+      run: npm ci
+
+    - name: Check docs are up to date
+      run: npm run test:docs

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "lint": "eslint \"lib/**/*.mjs\" \"test/test-*.mjs\" \"examples/*.js\" \"examples/*.mjs\" \"scripts/*.mjs\" rollup.config.mjs",
     "test": "npm run lint && npm run build && npm run test:esm && npm run test:cjs",
     "test:esm": "tap test/test-*.mjs",
-    "test:cjs": "tap dist/test/test-*.js"
+    "test:cjs": "tap dist/test/test-*.js",
+    "test:docs": "npm run docs && git diff --exit-code docs/API.md"
   },
   "contributors": [
     "Hans Hübner <hans.huebner@gmail.com>",


### PR DESCRIPTION
Adds a `test:docs` npm script and a dedicated CI job that regenerates docs/API.md and fails if the result differs from what is committed. This catches both manual edits to the generated file and forgetting to run `npm run docs` after changing JSDoc.