### PR TITLE
fix(ci): catch docs/API.md deletion in test:docs check

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "npm run lint && npm run build && npm run test:esm && npm run test:cjs",
     "test:esm": "tap test/test-*.mjs",
     "test:cjs": "tap dist/test/test-*.js",
-    "test:docs": "npm run docs && git diff --exit-code docs/API.md"
+    "test:docs": "npm run docs && git diff --exit-code docs/API.md && git ls-files --error-unmatch docs/API.md"
   },
   "contributors": [
     "Hans Hübner <hans.huebner@gmail.com>",


### PR DESCRIPTION
git diff --exit-code only inspects tracked files, so if docs/API.md is removed from the index and npm run docs recreates it as an untracked file the check silently passes. Adding git ls-files --error-unmatch fails the check when the file is absent from the index.